### PR TITLE
Nick/spec file/game stats

### DIFF
--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -5,7 +5,7 @@ class GameStats
   attr_reader :games
 
   def initialize(data)
-    @data = CSV.parse (File.read(data)), headers: true, header_converters: :symbol
+    @data = CSV.parse (File.read(data[:games])), headers: true, header_converters: :symbol
     @games = []
     build_games(@data)
   end

--- a/spec/game_stats_spec.rb
+++ b/spec/game_stats_spec.rb
@@ -4,7 +4,16 @@ require './lib/game'
 require 'csv'
 
 describe GameStats do
-  let(:game_stats) {game_stats = GameStats.new('data/games.csv')}
+  game_path = './data/games.csv'
+  team_path = './data/teams.csv'
+  game_teams_path = './data/game_teams.csv'
+
+  data_hash = {
+    games: game_path,
+    teams: team_path,
+    game_teams: game_teams_path
+  }
+  let(:game_stats) {game_stats = GameStats.new(data_hash)}
   describe "#initialize" do
     it "exists" do
 


### PR DESCRIPTION
Small change to how GameStats receives data in the #initialize method.  It now will take a Hash, which should contain keys that point to specific filepaths. 
then CSV is used to read the specific filepath for the games data.

I think this pattern will be useful when we put everything together, and could be a very useful way for our other stats classes to gain access to data sets from both teams.csv and game_teams.csv