### PR TITLE
Nick/test coverage/all

### DIFF
--- a/lib/game_stats.rb
+++ b/lib/game_stats.rb
@@ -66,14 +66,6 @@ class GameStats
   end
 
   def average_goals_per_game
-    percent = @games.find_all do |game|
-
-      game.home_goals + game.away_goals  
-    end
-    ((percent.length.to_f) / (@games.length.to_f)).round(2)
-  end
-
-  def average_goals_per_game
     goals = @games.sum do |game|
       game.home_goals + game.away_goals
     end

--- a/lib/league_stats.rb
+++ b/lib/league_stats.rb
@@ -74,11 +74,11 @@ class LeagueStats < Stats
   def team_info(team_id)
     team = find_team_by_id(team_id)
     info = {
-      team_id: team.id,
-      franchise_id: team.franchise_id,
-      team_name: team.name,
-      abbreviation: team.abbreviation,
-      link: team.link
+      "team_id" => team.id,
+      "franchise_id" => team.franchise_id,
+      "team_name" => team.name,
+      "abbreviation" => team.abbreviation,
+      "link" => team.link
     }
     info
   end

--- a/spec/league_stats_spec.rb
+++ b/spec/league_stats_spec.rb
@@ -79,11 +79,11 @@ describe LeagueStats do
     it "returns the info for the team specified by team_id" do
       team_id = "1"
       expected_info = {
-        team_id: "1",                      
-        franchise_id: "23",
-        team_name: "Atlanta United",
-        abbreviation: "ATL",
-        link: "/api/v1/teams/1"
+        "team_id" => "1",                      
+        "franchise_id" => "23",
+        "team_name" => "Atlanta United",
+        "abbreviation"=> "ATL",
+        "link" => "/api/v1/teams/1"
       }
       expect(league_stats.team_info(team_id)).to eq expected_info 
     end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -86,4 +86,24 @@ RSpec.describe StatTracker do
   it "#hightest_scoring_home_team" do
     expect(@stat_tracker.highest_scoring_home_team).to eq "Reign FC"
   end
+
+  it "#lowest_scoring_visitor" do
+    expect(@stat_tracker.lowest_scoring_visitor).to eq "San Jose Earthquakes"
+  end
+
+  it "#lowest_scoring_home_team" do
+    expect(@stat_tracker.lowest_scoring_home_team).to eq "Utah Royals FC"
+  end
+
+  it "#team_info" do
+  expected = {
+    "team_id" => "18",
+    "franchise_id" => "34",
+    "team_name" => "Minnesota United FC",
+    "abbreviation" => "MIN",
+    "link" => "/api/v1/teams/18"
+  }
+
+  expect(@stat_tracker.team_info("18")).to eq expected
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -74,4 +74,16 @@ RSpec.describe StatTracker do
   it "#best_offense" do
     expect(@stat_tracker.best_offense).to eq "Reign FC"
   end
+
+  it "#worst_offense" do
+    expect(@stat_tracker.worst_offense).to eq "Utah Royals FC"
+  end
+
+  it "#highest_scoring_visitor" do 
+    expect(@stat_tracker.highest_scoring_visitor).to eq "FC Dallas"
+  end
+
+  it "#hightest_scoring_home_team" do
+    expect(@stat_tracker.highest_scoring_home_team).to eq "Reign FC"
+  end
 end

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -66,4 +66,12 @@ RSpec.describe StatTracker do
     }
     expect(@stat_tracker.average_goals_by_season).to eq expected
   end
+
+  it "#count_of_teams" do 
+    expect(@stat_tracker.count_of_teams).to eq 32
+  end
+
+  it "#best_offense" do
+    expect(@stat_tracker.best_offense).to eq "Reign FC"
+  end
 end


### PR DESCRIPTION
Add: 
Stat tracker test coverage 
-#best_offense test
-#worst_offense test
-#highest_scoring_visitor test
-#Highest_scoring_home_team test
-#lowest_scoring_visitor test
-#lowest_scoring_home_team test
-#team_info test, and adjusted Hash format from #team info method to meet spec harness expected outputs

Remove:
-Old version of average_goals_per_game that was a duplicate 