### PR TITLE
Ethan/Debug/League_Stats_Class

### DIFF
--- a/lib/league_stats.rb
+++ b/lib/league_stats.rb
@@ -74,11 +74,11 @@ class LeagueStats < Stats
   def team_info(team_id)
     team = find_team_by_id(team_id)
     info = {
-      team_id: team.id,
-      franchise_id: team.franchise_id,
-      team_name: team.name,
-      abbreviation: team.abbreviation,
-      link: team.link
+      "team_id" => team.id,
+      "franchise_id" => team.franchise_id,
+      "team_name" => team.name,
+      "abbreviation" => team.abbreviation,
+      "link" => team.link
     }
     info
   end

--- a/spec/league_stats_spec.rb
+++ b/spec/league_stats_spec.rb
@@ -79,11 +79,11 @@ describe LeagueStats do
     it "returns the info for the team specified by team_id" do
       team_id = "1"
       expected_info = {
-        team_id: "1",                      
-        franchise_id: "23",
-        team_name: "Atlanta United",
-        abbreviation: "ATL",
-        link: "/api/v1/teams/1"
+        "team_id" => "1",                      
+        "franchise_id" => "23",
+        "team_name" => "Atlanta United",
+        "abbreviation" => "ATL",
+        "link" => "/api/v1/teams/1"
       }
       expect(league_stats.team_info(team_id)).to eq expected_info 
     end


### PR DESCRIPTION
Refactored the league_stats method `team_info` to have string keys instead of symbol keys since that's what the spec_harness was looking for. Updated the spec file to account for the strings as well.